### PR TITLE
Fix form falsy-value handling, add regression tests, and correct documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,21 @@
 
 [![npm package](https://upload.wikimedia.org/wikipedia/commons/thumb/d/db/Npm-logo.svg/320px-Npm-logo.svg.png)](https://www.npmjs.com/package/playwright-components)
 
-Set of page object components to help in complex playwright projects.
+Set of page object components to help with complex Playwright projects.
 
-These components assume that you're using a page object / component object approach to you web testing.
+These components assume that you're using a page object / component object approach for your web testing.
 
-It also assumes that your web UI under test abliges to the accessibility best practices from [WCAG 2](https://www.w3.org/WAI/standards-guidelines/wcag)
+It also assumes that your web UI under test adheres to the accessibility best practices from [WCAG 2](https://www.w3.org/WAI/standards-guidelines/wcag).
 
 ## Installation
 
-On a project only for testing
+For a project used only for testing:
 
 ```
 npm i playwright-components
 ```
 
-On project with tests
+For a project with tests:
 
 ```
 npm i -D playwright-components

--- a/src/components/dialog.ts
+++ b/src/components/dialog.ts
@@ -36,13 +36,13 @@ export class DialogComponent {
   }
 
   /**
-   * Clicks the button in this dialog with the given acessible name.
+   * Clicks the button in this dialog with the given accessible name.
    *
-   * @param name - The acessible name of the button. (case insensitive)
+   * @param name - The accessible name of the button. (case insensitive)
    *
    * @example
    * ```
-   * // clicks the dialog button with acessible name "create".
+   * // clicks the dialog button with accessible name "create".
    * await myDialog.click("create");
    * ```
    */

--- a/src/components/form.ts
+++ b/src/components/form.ts
@@ -77,7 +77,7 @@ export class FormComponent {
    * ```
    */
   async fillOne(field: string, value?: FillValue | Entity) {
-    if (!value) {
+    if (value === undefined) {
       return;
     }
 

--- a/src/components/table.ts
+++ b/src/components/table.ts
@@ -43,7 +43,7 @@ export class TableComponent {
   /**
    * Returns the Locator for a column header.
    *
-   * @param text - The column header text or acessible name. (case insencitive)
+   * @param text - The column header text or accessible name. (case insensitive)
    *
    * @example
    * ```
@@ -70,7 +70,7 @@ export class TableComponent {
   /**
    * Returns the Locator for a table body row.
    *
-   * @param text - The partial row text or acessible name. (case insencitive)
+   * @param text - The partial row text or accessible name. (case insensitive)
    *
    * @example
    * ```

--- a/tests/components/form/form.spec.ts
+++ b/tests/components/form/form.spec.ts
@@ -54,6 +54,42 @@ test("should be able to fill checkbox input with phrase on form", async ({
   await expect(formPage.form.root.getByLabel("I Can Drive")).toBeChecked();
 });
 
+test("should be able to fill checkbox input with false on form", async ({
+  formPage,
+}) => {
+  // GIVEN
+  await formPage.form.fillOne("iCanDrive", true);
+
+  // WHEN
+  await formPage.form.fillOne("iCanDrive", false);
+
+  // THEN
+  await expect(formPage.form.root.getByLabel("I Can Drive")).not.toBeChecked();
+});
+
+test("should be able to fill number input with zero on form", async ({
+  formPage,
+}) => {
+  // WHEN
+  await formPage.form.fillOne("age", 0);
+
+  // THEN
+  await expect(formPage.form.root.getByLabel("age")).toHaveValue("0");
+});
+
+test("should be able to fill text input with empty string on form", async ({
+  formPage,
+}) => {
+  // GIVEN
+  await formPage.form.fillOne("name", "angie");
+
+  // WHEN
+  await formPage.form.fillOne("name", "");
+
+  // THEN
+  await expect(formPage.form.root.getByLabel("name")).toHaveValue("");
+});
+
 test("should be able to fill all inputs on form", async ({ formPage }) => {
   // WHEN
   await formPage.form.fillAll({


### PR DESCRIPTION
### Motivation
- `FormComponent.fillOne` incorrectly returned early for all falsy values, preventing explicit fills of `false`, `0`, and `""` and causing functional bugs in form usage.
- Documentation and JSDoc contain spelling and wording issues that reduce clarity and professional presentation.
- Tests were missing coverage for `fillOne` behavior with falsy values, which increases risk of regressions.

### Description
- Change the guard in `FormComponent.fillOne` to only return early for `undefined` by replacing `if (!value)` with `if (value === undefined)` in `src/components/form.ts`.
- Add regression tests in `tests/components/form/form.spec.ts` covering `fillOne` with `false`, `0`, and an empty string to ensure correct behavior for checkbox, number, and text inputs.
- Fix README wording and grammar in the introduction and installation sections in `README.md`.
- Correct JSDoc spelling/wording in `src/components/dialog.ts` and `src/components/table.ts` (e.g., `accessible`, `insensitive`) to improve inline documentation.
- Run and apply code formatting with `prettier` to keep code style consistent.

### Testing
- Ran type checks with `npm run lint:types` (`tsc --noEmit`) which succeeded.
- Ran `npx prettier --check` on modified files which passed after applying `npx prettier --write` to fix formatting issues.
- Executed `npm test -- tests/components/form/form.spec.ts`, which could not complete in this environment because Playwright browser binaries are missing and Playwright test run failed with a missing executable error.
- Attempted to remediate by running `npx playwright install chromium`, but the browser download failed due to network/socket errors (`ERR_SOCKET_CLOSED`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a33b58318083258f6d61b725831b9e)